### PR TITLE
[pr] Fixed core dump

### DIFF
--- a/src/ngx_http_php_core.c
+++ b/src/ngx_http_php_core.c
@@ -246,7 +246,7 @@ ngx_php_error_cb(int type,
 
             efree(buffer);
             efree(log_buffer);
-            zend_bailout();
+            //zend_bailout();
 
             //ngx_http_php_zend_uthread_exit(r);
             return ;

--- a/src/ngx_http_php_core.h
+++ b/src/ngx_http_php_core.h
@@ -131,6 +131,8 @@ typedef struct ngx_http_php_ctx_s {
 
     zval *recv_buf;
 
+    unsigned end_of_request : 1;
+
 } ngx_http_php_ctx_t;
 
 

--- a/src/ngx_http_php_handler.c
+++ b/src/ngx_http_php_handler.c
@@ -69,6 +69,7 @@ ngx_http_php_post_read_handler(ngx_http_request_t *r)
         ctx->access_phase = 0;
         ctx->content_phase = 0;
         ctx->phase_status = NGX_DECLINED;
+        ctx->end_of_request = 0;
         ngx_memzero(&ctx->sleep, sizeof(ngx_event_t));
     }
 
@@ -207,6 +208,8 @@ set_output:
 
     ctx->phase_status = NGX_DECLINED;
 
+    ctx->end_of_request = 1;
+
     if ( rc == NGX_OK || rc == NGX_HTTP_OK ) {
 
         chain = ctx->rputs_chain;
@@ -310,6 +313,7 @@ set_output:
     ctx = ngx_http_get_module_ctx(r, ngx_http_php_module);
 
     if ( ctx == NULL ) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ngx_php ctx is nil at rewrite inline handler.");
         return NGX_ERROR;
     }
 
@@ -318,6 +322,8 @@ set_output:
     }
 
     ctx->phase_status = NGX_DECLINED;
+
+    ctx->end_of_request = 1;
 
     if ( rc == NGX_OK || rc == NGX_HTTP_OK ) {
         chain = ctx->rputs_chain;
@@ -486,6 +492,8 @@ set_output:
 
     ctx->phase_status = NGX_DECLINED;
 
+    ctx->end_of_request = 1;
+
     if (rc == NGX_OK || rc == NGX_HTTP_OK) {
 
         chain = ctx->rputs_chain;
@@ -593,6 +601,7 @@ set_output:
     ctx = ngx_http_get_module_ctx(r, ngx_http_php_module);
 
     if ( ctx == NULL ) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ngx_php ctx is nil at access inline handler.");
         return NGX_ERROR;
     }
 
@@ -601,6 +610,8 @@ set_output:
     }
 
     ctx->phase_status = NGX_DECLINED;
+
+    ctx->end_of_request = 1;
 
     if (rc == NGX_OK || rc == NGX_HTTP_OK) {
 
@@ -819,6 +830,8 @@ set_output:
 
     ctx->phase_status = NGX_DECLINED;
 
+    ctx->end_of_request = 1;
+
     if (rc == NGX_OK || rc == NGX_DECLINED) {
 
         chain = ctx->rputs_chain;
@@ -998,6 +1011,8 @@ set_output:
     }
 
     ctx->phase_status = NGX_DECLINED;
+
+    ctx->end_of_request = 1;
 
     if (rc == NGX_OK || rc == NGX_DECLINED) {
 

--- a/src/ngx_http_php_zend_uthread.c
+++ b/src/ngx_http_php_zend_uthread.c
@@ -219,7 +219,12 @@ static int ngx_http_php_zend_call_function(zend_fcall_info *fci, zend_fcall_info
     fci->object = (func->common.fn_flags & ZEND_ACC_STATIC) ?
         NULL : fci_cache->object;
 
-    call = zend_vm_stack_push_call_frame(ZEND_CALL_TOP_FUNCTION | ZEND_CALL_DYNAMIC,
+    call = zend_vm_stack_push_call_frame( 
+#if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 1
+        ZEND_CALL_TOP_FUNCTION,
+#else
+        ZEND_CALL_TOP_FUNCTION | ZEND_CALL_DYNAMIC,
+#endif
         func, fci->param_count, fci_cache->called_scope, fci->object);
 
     if (UNEXPECTED(func->common.fn_flags & ZEND_ACC_DEPRECATED)) {

--- a/src/ngx_http_php_zend_uthread.c
+++ b/src/ngx_http_php_zend_uthread.c
@@ -37,6 +37,7 @@ static int ngx_http_php_zend_eval_stringl_ex(char *str, size_t str_len, zval *re
 
 static int ngx_http_php__call_user_function_ex(zval *object, zval *function_name, zval *retval_ptr, uint32_t param_count, zval params[], int no_separation);
 static int ngx_http_php_zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache);
+static int ngx_http_php_zend_call_function_v70(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache);
 
 static void ngx_http_php_zend_throw_exception_internal(zval *exception);
 
@@ -130,7 +131,13 @@ static int ngx_http_php__call_user_function_ex(zval *object, zval *function_name
     fci.params = params;
     fci.no_separation = (zend_bool) no_separation;
 
+#if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 1
+    fci.function_table = function_table;
+    fci.symbol_table = symbol_table;
+    return ngx_http_php_zend_call_function_v70(&fci, NULL);
+#else
     return ngx_http_php_zend_call_function(&fci, NULL);
+#endif
 }
 
 static int ngx_http_php_zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /* {{{ */
@@ -381,6 +388,275 @@ static int ngx_http_php_zend_call_function(zend_fcall_info *fci, zend_fcall_info
 #endif
     }
 
+    return SUCCESS;
+}
+
+static int ngx_http_php_zend_call_function_v70(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache)
+{
+    uint32_t i;
+    zend_class_entry *calling_scope = NULL;
+    zend_execute_data *call, dummy_execute_data;
+    zend_fcall_info_cache fci_cache_local;
+    zend_function *func;
+    zend_class_entry *orig_scope;
+
+    ZVAL_UNDEF(fci->retval);
+
+    if (!EG(active)) {
+        return FAILURE; /* executor is already inactive */
+    }
+
+    if (EG(exception)) {
+        return FAILURE; /* we would result in an instable executor otherwise */
+    }
+
+    switch (fci->size) {
+        case sizeof(zend_fcall_info):
+            break; /* nothing to do currently */
+        default:
+            zend_error_noreturn(E_CORE_ERROR, "Corrupted fcall_info provided to zend_call_function()");
+            break;
+    }
+
+    orig_scope = EG(scope);
+
+    /* Initialize execute_data */
+    if (!EG(current_execute_data)) {
+        /* This only happens when we're called outside any execute()'s
+         * It shouldn't be strictly necessary to NULL execute_data out,
+         * but it may make bugs easier to spot
+         */
+        memset(&dummy_execute_data, 0, sizeof(zend_execute_data));
+        EG(current_execute_data) = &dummy_execute_data;
+    } else if (EG(current_execute_data)->func &&
+               ZEND_USER_CODE(EG(current_execute_data)->func->common.type) &&
+               EG(current_execute_data)->opline->opcode != ZEND_DO_FCALL &&
+               EG(current_execute_data)->opline->opcode != ZEND_DO_ICALL &&
+               EG(current_execute_data)->opline->opcode != ZEND_DO_UCALL &&
+               EG(current_execute_data)->opline->opcode != ZEND_DO_FCALL_BY_NAME) {
+        /* Insert fake frame in case of include or magic calls */
+        dummy_execute_data = *EG(current_execute_data);
+        dummy_execute_data.prev_execute_data = EG(current_execute_data);
+        dummy_execute_data.call = NULL;
+        dummy_execute_data.opline = NULL;
+        dummy_execute_data.func = NULL;
+        EG(current_execute_data) = &dummy_execute_data;
+    }
+
+    if (!fci_cache || !fci_cache->initialized) {
+        zend_string *callable_name;
+        char *error = NULL;
+
+        if (!fci_cache) {
+            fci_cache = &fci_cache_local;
+        }
+
+        if (!zend_is_callable_ex(&fci->function_name, fci->object, IS_CALLABLE_CHECK_SILENT, &callable_name, fci_cache, &error)) {
+            if (error) {
+                zend_error(E_WARNING, "Invalid callback %s, %s", ZSTR_VAL(callable_name), error);
+                efree(error);
+            }
+            if (callable_name) {
+                zend_string_release(callable_name);
+            }
+            if (EG(current_execute_data) == &dummy_execute_data) {
+                EG(current_execute_data) = dummy_execute_data.prev_execute_data;
+            }
+            return FAILURE;
+        } else if (error) {
+            /* Capitalize the first latter of the error message */
+            if (error[0] >= 'a' && error[0] <= 'z') {
+                error[0] += ('A' - 'a');
+            }
+            zend_error(E_DEPRECATED, "%s", error);
+            efree(error);
+            if (UNEXPECTED(EG(exception))) {
+                if (callable_name) {
+                    zend_string_release(callable_name);
+                }
+                if (EG(current_execute_data) == &dummy_execute_data) {
+                    EG(current_execute_data) = dummy_execute_data.prev_execute_data;
+                }
+                return FAILURE;
+            }
+        }
+        zend_string_release(callable_name);
+    }
+
+    func = fci_cache->function_handler;
+    call = zend_vm_stack_push_call_frame(ZEND_CALL_TOP_FUNCTION,
+        func, fci->param_count, fci_cache->called_scope, fci_cache->object);
+    calling_scope = fci_cache->calling_scope;
+    fci->object = fci_cache->object;
+    if (fci->object &&
+        (!EG(objects_store).object_buckets ||
+         !IS_OBJ_VALID(EG(objects_store).object_buckets[fci->object->handle]))) {
+        if (EG(current_execute_data) == &dummy_execute_data) {
+            EG(current_execute_data) = dummy_execute_data.prev_execute_data;
+        }
+        return FAILURE;
+    }
+
+    if (func->common.fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_DEPRECATED)) {
+        if (func->common.fn_flags & ZEND_ACC_ABSTRACT) {
+            zend_throw_error(NULL, "Cannot call abstract method %s::%s()", ZSTR_VAL(func->common.scope->name), ZSTR_VAL(func->common.function_name));
+            if (EG(current_execute_data) == &dummy_execute_data) {
+                EG(current_execute_data) = dummy_execute_data.prev_execute_data;
+            }
+            return FAILURE;
+        }
+        if (func->common.fn_flags & ZEND_ACC_DEPRECATED) {
+            zend_error(E_DEPRECATED, "Function %s%s%s() is deprecated",
+                func->common.scope ? ZSTR_VAL(func->common.scope->name) : "",
+                func->common.scope ? "::" : "",
+                ZSTR_VAL(func->common.function_name));
+        }
+    }
+
+    for (i=0; i<fci->param_count; i++) {
+        zval *param;
+        zval *arg = &fci->params[i];
+
+        if (ARG_SHOULD_BE_SENT_BY_REF(func, i + 1)) {
+            if (UNEXPECTED(!Z_ISREF_P(arg))) {
+                if (fci->no_separation &&
+                    !ARG_MAY_BE_SENT_BY_REF(func, i + 1)) {
+                    if (i) {
+                        /* hack to clean up the stack */
+                        ZEND_CALL_NUM_ARGS(call) = i;
+                        zend_vm_stack_free_args(call);
+                    }
+                    zend_vm_stack_free_call_frame(call);
+
+                    zend_error(E_WARNING, "Parameter %d to %s%s%s() expected to be a reference, value given",
+                        i+1,
+                        func->common.scope ? ZSTR_VAL(func->common.scope->name) : "",
+                        func->common.scope ? "::" : "",
+                        ZSTR_VAL(func->common.function_name));
+                    if (EG(current_execute_data) == &dummy_execute_data) {
+                        EG(current_execute_data) = dummy_execute_data.prev_execute_data;
+                    }
+                    return FAILURE;
+                }
+
+                ZVAL_NEW_REF(arg, arg);
+            }
+            Z_ADDREF_P(arg);
+        } else {
+            if (Z_ISREF_P(arg) &&
+                !(func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)) {
+                /* don't separate references for __call */
+                arg = Z_REFVAL_P(arg);
+            }
+            if (Z_OPT_REFCOUNTED_P(arg)) {
+                Z_ADDREF_P(arg);
+            }
+        }
+        param = ZEND_CALL_ARG(call, i+1);
+        ZVAL_COPY_VALUE(param, arg);
+    }
+
+    EG(scope) = calling_scope;
+    if (func->common.fn_flags & ZEND_ACC_STATIC) {
+        fci->object = NULL;
+    }
+    Z_OBJ(call->This) = fci->object;
+
+    if (UNEXPECTED(func->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
+        ZEND_ASSERT(GC_TYPE((zend_object*)func->op_array.prototype) == IS_OBJECT);
+        GC_REFCOUNT((zend_object*)func->op_array.prototype)++;
+        ZEND_ADD_CALL_FLAG(call, ZEND_CALL_CLOSURE);
+    }
+
+    /* PHP-7 doesn't support symbol_table substitution for functions */
+    ZEND_ASSERT(fci->symbol_table == NULL);
+
+    if (func->type == ZEND_USER_FUNCTION) {
+        int call_via_handler = (func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) != 0;
+        EG(scope) = func->common.scope;
+        call->symbol_table = fci->symbol_table;
+        if (EXPECTED((func->op_array.fn_flags & ZEND_ACC_GENERATOR) == 0)) {
+            const zend_op *current_opline_before_exception = EG(opline_before_exception);
+
+            zend_init_execute_data(call, &func->op_array, fci->retval);
+            zend_execute_ex(call);
+            EG(opline_before_exception) = current_opline_before_exception;
+        } else {
+            zend_generator_create_zval(call, &func->op_array, fci->retval);
+        }
+        if (call_via_handler) {
+            /* We must re-initialize function again */
+            fci_cache->initialized = 0;
+        }
+    } else if (func->type == ZEND_INTERNAL_FUNCTION) {
+        int call_via_handler = (func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) != 0;
+        ZVAL_NULL(fci->retval);
+        if (func->common.scope) {
+            EG(scope) = func->common.scope;
+        }
+        call->prev_execute_data = EG(current_execute_data);
+        call->return_value = NULL; /* this is not a constructor call */
+        EG(current_execute_data) = call;
+        if (EXPECTED(zend_execute_internal == NULL)) {
+            /* saves one function call if zend_execute_internal is not used */
+            func->internal_function.handler(call, fci->retval);
+        } else {
+            zend_execute_internal(call, fci->retval);
+        }
+        EG(current_execute_data) = call->prev_execute_data;
+        zend_vm_stack_free_args(call);
+
+        /*  We shouldn't fix bad extensions here,
+            because it can break proper ones (Bug #34045)
+        if (!EX(function_state).function->common.return_reference)
+        {
+            INIT_PZVAL(f->retval);
+        }*/
+        if (EG(exception)) {
+            zval_ptr_dtor(fci->retval);
+            ZVAL_UNDEF(fci->retval);
+        }
+
+        if (call_via_handler) {
+            /* We must re-initialize function again */
+            fci_cache->initialized = 0;
+        }
+    } else { /* ZEND_OVERLOADED_FUNCTION */
+        ZVAL_NULL(fci->retval);
+
+        /* Not sure what should be done here if it's a static method */
+        if (fci->object) {
+            call->prev_execute_data = EG(current_execute_data);
+            EG(current_execute_data) = call;
+            fci->object->handlers->call_method(func->common.function_name, fci->object, call, fci->retval);
+            EG(current_execute_data) = call->prev_execute_data;
+        } else {
+            zend_throw_error(NULL, "Cannot call overloaded function for non-object");
+        }
+
+        zend_vm_stack_free_args(call);
+
+        if (func->type == ZEND_OVERLOADED_FUNCTION_TEMPORARY) {
+            zend_string_release(func->common.function_name);
+        }
+        efree(func);
+
+        if (EG(exception)) {
+            zval_ptr_dtor(fci->retval);
+            ZVAL_UNDEF(fci->retval);
+        }
+    }
+
+    EG(scope) = orig_scope;
+    zend_vm_stack_free_call_frame(call);
+
+    if (EG(current_execute_data) == &dummy_execute_data) {
+        EG(current_execute_data) = dummy_execute_data.prev_execute_data;
+    }
+
+    if (EG(exception)) {
+        ngx_http_php_zend_throw_exception_internal(NULL);
+    }
     return SUCCESS;
 }
 

--- a/src/ngx_http_php_zend_uthread.c
+++ b/src/ngx_http_php_zend_uthread.c
@@ -35,11 +35,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 static int ngx_http_php_zend_eval_stringl(char *str, size_t str_len, zval *retval_ptr, char *string_name);
 static int ngx_http_php_zend_eval_stringl_ex(char *str, size_t str_len, zval *retval_ptr, char *string_name, int handle_exceptions);
 
+#if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION > 0
 static int ngx_http_php__call_user_function_ex(zval *object, zval *function_name, zval *retval_ptr, uint32_t param_count, zval params[], int no_separation);
 static int ngx_http_php_zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache);
-static int ngx_http_php_zend_call_function_v70(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache);
-
 static void ngx_http_php_zend_throw_exception_internal(zval *exception);
+#endif
 
 static int ngx_http_php_zend_eval_stringl(char *str, size_t str_len, zval *retval_ptr, char *string_name) /* {{{ */
 {
@@ -119,6 +119,7 @@ static int ngx_http_php_zend_eval_stringl_ex(char *str, size_t str_len, zval *re
 }
 /* }}} */
 
+#if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION > 0
 static int ngx_http_php__call_user_function_ex(zval *object, zval *function_name, zval *retval_ptr, uint32_t param_count, zval params[], int no_separation) /* {{{ */
 {
     zend_fcall_info fci;
@@ -131,13 +132,7 @@ static int ngx_http_php__call_user_function_ex(zval *object, zval *function_name
     fci.params = params;
     fci.no_separation = (zend_bool) no_separation;
 
-#if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 1
-    fci.function_table = function_table;
-    fci.symbol_table = symbol_table;
-    return ngx_http_php_zend_call_function_v70(&fci, NULL);
-#else
     return ngx_http_php_zend_call_function(&fci, NULL);
-#endif
 }
 
 static int ngx_http_php_zend_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache) /* {{{ */
@@ -391,275 +386,6 @@ static int ngx_http_php_zend_call_function(zend_fcall_info *fci, zend_fcall_info
     return SUCCESS;
 }
 
-static int ngx_http_php_zend_call_function_v70(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache)
-{
-    uint32_t i;
-    zend_class_entry *calling_scope = NULL;
-    zend_execute_data *call, dummy_execute_data;
-    zend_fcall_info_cache fci_cache_local;
-    zend_function *func;
-    zend_class_entry *orig_scope;
-
-    ZVAL_UNDEF(fci->retval);
-
-    if (!EG(active)) {
-        return FAILURE; /* executor is already inactive */
-    }
-
-    if (EG(exception)) {
-        return FAILURE; /* we would result in an instable executor otherwise */
-    }
-
-    switch (fci->size) {
-        case sizeof(zend_fcall_info):
-            break; /* nothing to do currently */
-        default:
-            zend_error_noreturn(E_CORE_ERROR, "Corrupted fcall_info provided to zend_call_function()");
-            break;
-    }
-
-    orig_scope = EG(scope);
-
-    /* Initialize execute_data */
-    if (!EG(current_execute_data)) {
-        /* This only happens when we're called outside any execute()'s
-         * It shouldn't be strictly necessary to NULL execute_data out,
-         * but it may make bugs easier to spot
-         */
-        memset(&dummy_execute_data, 0, sizeof(zend_execute_data));
-        EG(current_execute_data) = &dummy_execute_data;
-    } else if (EG(current_execute_data)->func &&
-               ZEND_USER_CODE(EG(current_execute_data)->func->common.type) &&
-               EG(current_execute_data)->opline->opcode != ZEND_DO_FCALL &&
-               EG(current_execute_data)->opline->opcode != ZEND_DO_ICALL &&
-               EG(current_execute_data)->opline->opcode != ZEND_DO_UCALL &&
-               EG(current_execute_data)->opline->opcode != ZEND_DO_FCALL_BY_NAME) {
-        /* Insert fake frame in case of include or magic calls */
-        dummy_execute_data = *EG(current_execute_data);
-        dummy_execute_data.prev_execute_data = EG(current_execute_data);
-        dummy_execute_data.call = NULL;
-        dummy_execute_data.opline = NULL;
-        dummy_execute_data.func = NULL;
-        EG(current_execute_data) = &dummy_execute_data;
-    }
-
-    if (!fci_cache || !fci_cache->initialized) {
-        zend_string *callable_name;
-        char *error = NULL;
-
-        if (!fci_cache) {
-            fci_cache = &fci_cache_local;
-        }
-
-        if (!zend_is_callable_ex(&fci->function_name, fci->object, IS_CALLABLE_CHECK_SILENT, &callable_name, fci_cache, &error)) {
-            if (error) {
-                zend_error(E_WARNING, "Invalid callback %s, %s", ZSTR_VAL(callable_name), error);
-                efree(error);
-            }
-            if (callable_name) {
-                zend_string_release(callable_name);
-            }
-            if (EG(current_execute_data) == &dummy_execute_data) {
-                EG(current_execute_data) = dummy_execute_data.prev_execute_data;
-            }
-            return FAILURE;
-        } else if (error) {
-            /* Capitalize the first latter of the error message */
-            if (error[0] >= 'a' && error[0] <= 'z') {
-                error[0] += ('A' - 'a');
-            }
-            zend_error(E_DEPRECATED, "%s", error);
-            efree(error);
-            if (UNEXPECTED(EG(exception))) {
-                if (callable_name) {
-                    zend_string_release(callable_name);
-                }
-                if (EG(current_execute_data) == &dummy_execute_data) {
-                    EG(current_execute_data) = dummy_execute_data.prev_execute_data;
-                }
-                return FAILURE;
-            }
-        }
-        zend_string_release(callable_name);
-    }
-
-    func = fci_cache->function_handler;
-    call = zend_vm_stack_push_call_frame(ZEND_CALL_TOP_FUNCTION,
-        func, fci->param_count, fci_cache->called_scope, fci_cache->object);
-    calling_scope = fci_cache->calling_scope;
-    fci->object = fci_cache->object;
-    if (fci->object &&
-        (!EG(objects_store).object_buckets ||
-         !IS_OBJ_VALID(EG(objects_store).object_buckets[fci->object->handle]))) {
-        if (EG(current_execute_data) == &dummy_execute_data) {
-            EG(current_execute_data) = dummy_execute_data.prev_execute_data;
-        }
-        return FAILURE;
-    }
-
-    if (func->common.fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_DEPRECATED)) {
-        if (func->common.fn_flags & ZEND_ACC_ABSTRACT) {
-            zend_throw_error(NULL, "Cannot call abstract method %s::%s()", ZSTR_VAL(func->common.scope->name), ZSTR_VAL(func->common.function_name));
-            if (EG(current_execute_data) == &dummy_execute_data) {
-                EG(current_execute_data) = dummy_execute_data.prev_execute_data;
-            }
-            return FAILURE;
-        }
-        if (func->common.fn_flags & ZEND_ACC_DEPRECATED) {
-            zend_error(E_DEPRECATED, "Function %s%s%s() is deprecated",
-                func->common.scope ? ZSTR_VAL(func->common.scope->name) : "",
-                func->common.scope ? "::" : "",
-                ZSTR_VAL(func->common.function_name));
-        }
-    }
-
-    for (i=0; i<fci->param_count; i++) {
-        zval *param;
-        zval *arg = &fci->params[i];
-
-        if (ARG_SHOULD_BE_SENT_BY_REF(func, i + 1)) {
-            if (UNEXPECTED(!Z_ISREF_P(arg))) {
-                if (fci->no_separation &&
-                    !ARG_MAY_BE_SENT_BY_REF(func, i + 1)) {
-                    if (i) {
-                        /* hack to clean up the stack */
-                        ZEND_CALL_NUM_ARGS(call) = i;
-                        zend_vm_stack_free_args(call);
-                    }
-                    zend_vm_stack_free_call_frame(call);
-
-                    zend_error(E_WARNING, "Parameter %d to %s%s%s() expected to be a reference, value given",
-                        i+1,
-                        func->common.scope ? ZSTR_VAL(func->common.scope->name) : "",
-                        func->common.scope ? "::" : "",
-                        ZSTR_VAL(func->common.function_name));
-                    if (EG(current_execute_data) == &dummy_execute_data) {
-                        EG(current_execute_data) = dummy_execute_data.prev_execute_data;
-                    }
-                    return FAILURE;
-                }
-
-                ZVAL_NEW_REF(arg, arg);
-            }
-            Z_ADDREF_P(arg);
-        } else {
-            if (Z_ISREF_P(arg) &&
-                !(func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)) {
-                /* don't separate references for __call */
-                arg = Z_REFVAL_P(arg);
-            }
-            if (Z_OPT_REFCOUNTED_P(arg)) {
-                Z_ADDREF_P(arg);
-            }
-        }
-        param = ZEND_CALL_ARG(call, i+1);
-        ZVAL_COPY_VALUE(param, arg);
-    }
-
-    EG(scope) = calling_scope;
-    if (func->common.fn_flags & ZEND_ACC_STATIC) {
-        fci->object = NULL;
-    }
-    Z_OBJ(call->This) = fci->object;
-
-    if (UNEXPECTED(func->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
-        ZEND_ASSERT(GC_TYPE((zend_object*)func->op_array.prototype) == IS_OBJECT);
-        GC_REFCOUNT((zend_object*)func->op_array.prototype)++;
-        ZEND_ADD_CALL_FLAG(call, ZEND_CALL_CLOSURE);
-    }
-
-    /* PHP-7 doesn't support symbol_table substitution for functions */
-    ZEND_ASSERT(fci->symbol_table == NULL);
-
-    if (func->type == ZEND_USER_FUNCTION) {
-        int call_via_handler = (func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) != 0;
-        EG(scope) = func->common.scope;
-        call->symbol_table = fci->symbol_table;
-        if (EXPECTED((func->op_array.fn_flags & ZEND_ACC_GENERATOR) == 0)) {
-            const zend_op *current_opline_before_exception = EG(opline_before_exception);
-
-            zend_init_execute_data(call, &func->op_array, fci->retval);
-            zend_execute_ex(call);
-            EG(opline_before_exception) = current_opline_before_exception;
-        } else {
-            zend_generator_create_zval(call, &func->op_array, fci->retval);
-        }
-        if (call_via_handler) {
-            /* We must re-initialize function again */
-            fci_cache->initialized = 0;
-        }
-    } else if (func->type == ZEND_INTERNAL_FUNCTION) {
-        int call_via_handler = (func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) != 0;
-        ZVAL_NULL(fci->retval);
-        if (func->common.scope) {
-            EG(scope) = func->common.scope;
-        }
-        call->prev_execute_data = EG(current_execute_data);
-        call->return_value = NULL; /* this is not a constructor call */
-        EG(current_execute_data) = call;
-        if (EXPECTED(zend_execute_internal == NULL)) {
-            /* saves one function call if zend_execute_internal is not used */
-            func->internal_function.handler(call, fci->retval);
-        } else {
-            zend_execute_internal(call, fci->retval);
-        }
-        EG(current_execute_data) = call->prev_execute_data;
-        zend_vm_stack_free_args(call);
-
-        /*  We shouldn't fix bad extensions here,
-            because it can break proper ones (Bug #34045)
-        if (!EX(function_state).function->common.return_reference)
-        {
-            INIT_PZVAL(f->retval);
-        }*/
-        if (EG(exception)) {
-            zval_ptr_dtor(fci->retval);
-            ZVAL_UNDEF(fci->retval);
-        }
-
-        if (call_via_handler) {
-            /* We must re-initialize function again */
-            fci_cache->initialized = 0;
-        }
-    } else { /* ZEND_OVERLOADED_FUNCTION */
-        ZVAL_NULL(fci->retval);
-
-        /* Not sure what should be done here if it's a static method */
-        if (fci->object) {
-            call->prev_execute_data = EG(current_execute_data);
-            EG(current_execute_data) = call;
-            fci->object->handlers->call_method(func->common.function_name, fci->object, call, fci->retval);
-            EG(current_execute_data) = call->prev_execute_data;
-        } else {
-            zend_throw_error(NULL, "Cannot call overloaded function for non-object");
-        }
-
-        zend_vm_stack_free_args(call);
-
-        if (func->type == ZEND_OVERLOADED_FUNCTION_TEMPORARY) {
-            zend_string_release(func->common.function_name);
-        }
-        efree(func);
-
-        if (EG(exception)) {
-            zval_ptr_dtor(fci->retval);
-            ZVAL_UNDEF(fci->retval);
-        }
-    }
-
-    EG(scope) = orig_scope;
-    zend_vm_stack_free_call_frame(call);
-
-    if (EG(current_execute_data) == &dummy_execute_data) {
-        EG(current_execute_data) = dummy_execute_data.prev_execute_data;
-    }
-
-    if (EG(exception)) {
-        ngx_http_php_zend_throw_exception_internal(NULL);
-    }
-    return SUCCESS;
-}
-
 static void ngx_http_php_zend_throw_exception_internal(zval *exception) /* {{{ */
 {
 #ifdef HAVE_DTRACE
@@ -754,6 +480,7 @@ ngx_http_php_zend_uthread_rewrite_inline_routine(ngx_http_request_t *r)
 
     }zend_end_try();
 }
+#endif
 
 void 
 ngx_http_php_zend_uthread_access_inline_routine(ngx_http_request_t *r)

--- a/src/ngx_http_php_zend_uthread.c
+++ b/src/ngx_http_php_zend_uthread.c
@@ -821,7 +821,7 @@ ngx_http_php_zend_uthread_resume(ngx_http_request_t *r)
     ngx_http_php_ctx_t *ctx = ngx_http_get_module_ctx(r, ngx_http_php_module);
 
     if (ctx == NULL) {
-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ngx_php ctx is nil at zend_uthread_resume.");
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "ngx_php ctx is nil at zend_uthread_resume");
         return ;
     }
 
@@ -859,10 +859,11 @@ ngx_http_php_zend_uthread_resume(ngx_http_request_t *r)
         //r = ngx_php_request;
         //ctx = ngx_http_get_module_ctx(r, ngx_http_php_module);
         ngx_php_debug("%d, %p, %p", Z_TYPE_P(closure), r, ctx);
-        if ( !ctx ) {
-            zval_ptr_dtor(closure);
-            efree(closure);
-            closure = NULL;
+        if ( ctx->end_of_request ) {
+            //zval_ptr_dtor(closure);
+            //efree(closure);
+            //closure = NULL;
+            ngx_log_error(NGX_LOG_ERR, r->connection->log, 0, "End of request and zend uthread has be shutdown");
             return;
         }
 

--- a/src/ngx_http_php_zend_uthread.c
+++ b/src/ngx_http_php_zend_uthread.c
@@ -436,6 +436,7 @@ static void ngx_http_php_zend_throw_exception_internal(zval *exception) /* {{{ *
     EG(opline_before_exception) = EG(current_execute_data)->opline;
     EG(current_execute_data)->opline = EG(exception_op);
 }
+#endif
 
 void 
 ngx_http_php_zend_uthread_rewrite_inline_routine(ngx_http_request_t *r)
@@ -480,7 +481,6 @@ ngx_http_php_zend_uthread_rewrite_inline_routine(ngx_http_request_t *r)
 
     }zend_end_try();
 }
-#endif
 
 void 
 ngx_http_php_zend_uthread_access_inline_routine(ngx_http_request_t *r)
@@ -852,8 +852,12 @@ ngx_http_php_zend_uthread_resume(ngx_http_request_t *r)
         }
         zval_ptr_dtor(&func_next);
 
-        r = ngx_php_request;
-        ctx = ngx_http_get_module_ctx(r, ngx_http_php_module);
+        /*
+        错误：变量‘ctx’能为‘longjmp’或‘vfork’所篡改 [-Werror=clobbered]
+        错误：实参‘r’可能为‘longjmp’或‘vfork’所篡改 [-Werror=clobbered]
+        */
+        //r = ngx_php_request;
+        //ctx = ngx_http_get_module_ctx(r, ngx_http_php_module);
         ngx_php_debug("%d, %p, %p", Z_TYPE_P(closure), r, ctx);
         if ( !ctx ) {
             zval_ptr_dtor(closure);

--- a/src/ngx_http_php_zend_uthread.h
+++ b/src/ngx_http_php_zend_uthread.h
@@ -37,6 +37,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <php_ini.h>
 #include <ext/standard/info.h>
 
+#define ngx_http_php_call_user_function(function_table, object, function_name, retval_ptr, param_count, params) \
+	ngx_http_php__call_user_function_ex(object, function_name, retval_ptr, param_count, params, 1)
+#define ngx_http_php_call_user_function_ex(function_table, object, function_name, retval_ptr, param_count, params, no_separation, symbol_table) \
+	ngx_http_php__call_user_function_ex(object, function_name, retval_ptr, param_count, params, no_separation)
+
 void ngx_http_php_zend_uthread_rewrite_inline_routine(ngx_http_request_t *r);
 void ngx_http_php_zend_uthread_access_inline_routine(ngx_http_request_t *r);
 void ngx_http_php_zend_uthread_content_inline_routine(ngx_http_request_t *r);

--- a/src/ngx_http_php_zend_uthread.h
+++ b/src/ngx_http_php_zend_uthread.h
@@ -42,6 +42,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	zend_string_release(s)
 #endif
 
+#if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 2
+#define zend_init_func_execute_data(ex, op_array, return_value) \
+	zend_init_execute_data(ex, op_array, return_value)
+#endif
 
 #define ngx_http_php_call_user_function(function_table, object, function_name, retval_ptr, param_count, params) \
 	ngx_http_php__call_user_function_ex(object, function_name, retval_ptr, param_count, params, 1)

--- a/src/ngx_http_php_zend_uthread.h
+++ b/src/ngx_http_php_zend_uthread.h
@@ -47,10 +47,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	zend_init_execute_data(ex, op_array, return_value)
 #endif
 
+#if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 1
+#define ngx_http_php_call_user_function(function_table, object, function_name, retval_ptr, param_count, params) \
+	call_user_function(function_table, object, function_name, retval_ptr, param_count, params)
+#else
 #define ngx_http_php_call_user_function(function_table, object, function_name, retval_ptr, param_count, params) \
 	ngx_http_php__call_user_function_ex(object, function_name, retval_ptr, param_count, params, 1)
 #define ngx_http_php_call_user_function_ex(function_table, object, function_name, retval_ptr, param_count, params, no_separation, symbol_table) \
 	ngx_http_php__call_user_function_ex(object, function_name, retval_ptr, param_count, params, no_separation)
+#endif
 
 void ngx_http_php_zend_uthread_rewrite_inline_routine(ngx_http_request_t *r);
 void ngx_http_php_zend_uthread_access_inline_routine(ngx_http_request_t *r);

--- a/src/ngx_http_php_zend_uthread.h
+++ b/src/ngx_http_php_zend_uthread.h
@@ -37,6 +37,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <php_ini.h>
 #include <ext/standard/info.h>
 
+#if PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION < 3
+#define zend_string_release_ex(s, persistent) \
+	zend_string_release(s)
+#endif
+
+
 #define ngx_http_php_call_user_function(function_table, object, function_name, retval_ptr, param_count, params) \
 	ngx_http_php__call_user_function_ex(object, function_name, retval_ptr, param_count, params, 1)
 #define ngx_http_php_call_user_function_ex(function_table, object, function_name, retval_ptr, param_count, params, no_separation, symbol_table) \


### PR DESCRIPTION
Commits on Feb 15, 2019
[src] Fix bug at error hander, uthread cause some coredump.
5f28ca7
[src] Temp removal, maybe php hash a bug what's will cause coredump.  …
0262ca4
[src] Hack function -> ngx_http_php_call_user_function.
c0af6e9
Commits on Feb 16, 2019
[src] Fixed implicit declaration of function zend_string_release_ex i…  …
636c6f2
[src] Fixed error: implicit declaration of function ‘GC_ADDREF’ [-Wer…  …
715232d
Commits on Feb 17, 2019
[src] Fixed error: implicit declaration of function ‘zend_get_callabl…  …
f48163b
[src] Fixed error: ‘ZEND_CALL_DYNAMIC’ undeclared (first use in this …  …
b5559bd
[src] Add function ngx_http_php_zend_call_function_v70 for version ph…  …
f750bff
[src] Do not use hack function call_user_function in php7.0
ef2c2e3
[src] Fixed 错误：变量‘ctx’能为‘longjmp’或‘vfork’所篡改 [-Werror=clobbered] …
1f55d9d
Commits on Feb 18, 2019
[src] Fixed core dump, end of request and zend uthread must be shutdown.
a0878c6
