### PR TITLE
Add extern declaration

### DIFF
--- a/src/ngx_http_php_core.h
+++ b/src/ngx_http_php_core.h
@@ -174,7 +174,7 @@ int ngx_http_php_code_read_post(char *buffer, uint count_bytes TSRMLS_DC);
 char *ngx_http_php_code_read_cookies(TSRMLS_D);
 int ngx_http_php_code_header_handler(sapi_header_struct *sapi_header, sapi_header_op_enum op, sapi_headers_struct *sapi_headers TSRMLS_DC);
 
-void (*old_zend_error_cb)(int, const char *, const uint, const char *, va_list);
+extern void (*old_zend_error_cb)(int, const char *, const uint, const char *, va_list);
 void ngx_php_error_cb(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args);
 
 #endif

--- a/src/ngx_http_php_module.c
+++ b/src/ngx_http_php_module.c
@@ -419,6 +419,10 @@ ngx_module_t ngx_http_php_module = {
     NGX_MODULE_V1_PADDING
 };
 
+ngx_http_request_t *ngx_php_request;
+
+void (*old_zend_error_cb)(int, const char *, const uint, const char *, va_list);
+
 static ngx_int_t 
 ngx_http_php_init(ngx_conf_t *cf)
 {

--- a/src/ngx_http_php_module.h
+++ b/src/ngx_http_php_module.h
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 extern ngx_module_t ngx_http_php_module;
-ngx_http_request_t *ngx_php_request;
+extern ngx_http_request_t *ngx_php_request;
 
 typedef struct ngx_http_php_main_conf_s {
 


### PR DESCRIPTION
- ngx_php_request
- old_zend_error_cb

Add extern declaration to header.

Allowing entities in ngx_http_php_module.c.

Fixed #101 