### PR TITLE
Add bash shebang to config

### DIFF
--- a/config
+++ b/config
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 ngx_addon_name=ngx_http_php7_module
 
 NGX_PHP_SRCS="$ngx_addon_dir/src/ngx_http_php_module.c \


### PR DESCRIPTION
Fix `./configure: 67: /ngx_php7/config: Bad substitution`

Ubuntu by default use `dash` as `sh`,  [info](https://wiki.ubuntu.com/DashAsBinSh).
So we force the `sh` to use `bash` in any distro.

In the travis test don't fail, because use the `bash` shebang:
https://github.com/rryqszq4/ngx_php7/blob/master/.travis/compiler.sh#L1
