### PR TITLE
Update dev test with PHP/8.5 and Nginx/1.28.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,10 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '<compile') }}
     uses: ./.github/workflows/build_22.04.yml
 
-  build_20-04:
-    name: Ubuntu 20.04
-    if: ${{ !contains(github.event.head_commit.message, '<20') }}
-    uses: ./.github/workflows/build_20.04.yml
+  #build_20-04:
+  #  name: Ubuntu 20.04
+  #  if: ${{ !contains(github.event.head_commit.message, '<20') }}
+  #  uses: ./.github/workflows/build_20.04.yml
  
   # Dinamyc build
   build_dynamic_24-04:
@@ -49,8 +49,8 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '<22') }}
     uses: ./.github/workflows/build_22.04_dynamic.yml
 
-  build_dynamic_20-04:
-    name: Ubuntu 20.04 dynamic
-    if: ${{ !contains(github.event.head_commit.message, '<20') }}
-    uses: ./.github/workflows/build_20.04_dynamic.yml
+  #build_dynamic_20-04:
+  #  name: Ubuntu 20.04 dynamic
+  #  if: ${{ !contains(github.event.head_commit.message, '<20') }}
+  #  uses: ./.github/workflows/build_20.04_dynamic.yml
 

--- a/.github/workflows/build_22.04.yml
+++ b/.github/workflows/build_22.04.yml
@@ -26,7 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get install -yqq cpanminus libxml2-dev systemtap-sdt-dev zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev libkrb5-dev
+        run: |
+          sudo apt update
+          sudo apt-get install -yqq cpanminus libxml2-dev systemtap-sdt-dev zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev libkrb5-dev
 
       - name: Setup PHP-${{ matrix.php_version }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/build_22.04_dynamic.yml
+++ b/.github/workflows/build_22.04_dynamic.yml
@@ -26,7 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get install -yqq cpanminus libxml2-dev systemtap-sdt-dev zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev libkrb5-dev
+        run: |
+          sudo apt update
+          sudo apt-get install -yqq cpanminus libxml2-dev systemtap-sdt-dev zlib1g-dev libpcre3-dev libargon2-0-dev libsodium-dev libkrb5-dev
 
       - name: Setup PHP-${{ matrix.php_version }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/build_24.04.yml
+++ b/.github/workflows/build_24.04.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         php_version: ["8.2", "8.3", "8.4"]
         # Only nginx stable and mainline versions for faster tests
-        nginx_version: ["1.25.5", "1.26.0", "1.27.3"]
+        nginx_version: ["1.25.5", "1.26.0", "1.27.3", "1.28.0"]
         # Disable fail-fast to allow all failing versions to fail in a
         # single build, rather than stopping when the first one fails.
       fail-fast: false
@@ -26,7 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get install -yqq cpanminus libxml2-dev systemtap-sdt-dev zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev redis-server redis-tools memcached
+        run: |
+          sudo apt update
+          sudo apt-get install -yqq cpanminus libxml2-dev systemtap-sdt-dev zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev redis-server redis-tools memcached
 
       - name: Setup PHP-${{ matrix.php_version }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/build_24.04_dynamic.yml
+++ b/.github/workflows/build_24.04_dynamic.yml
@@ -26,7 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get install -yqq cpanminus libxml2-dev systemtap-sdt-dev zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev redis-server redis-tools memcached
+        run: |
+          sudo apt update
+          sudo apt-get install -yqq cpanminus libxml2-dev systemtap-sdt-dev zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev redis-server redis-tools memcached
 
       - name: Setup PHP-${{ matrix.php_version }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/build_development.yml
+++ b/.github/workflows/build_development.yml
@@ -46,7 +46,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: sudo apt-get install -yqq cpanminus libxml2-dev systemtap-sdt-dev zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev redis-server redis-tools memcached
+        run: |
+          sudo apt update
+          sudo apt-get install -yqq cpanminus libxml2-dev systemtap-sdt-dev zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev redis-server redis-tools memcached
 
       - name: Setup PHP-${{ matrix.php_version }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/build_development.yml
+++ b/.github/workflows/build_development.yml
@@ -35,8 +35,8 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ["8.4"]
-        nginx_version: ["1.26.0"] 
+        php_version: ["8.5"]
+        nginx_version: ["1.28.0"] 
         # Disable fail-fast to allow all failing versions to fail in a
         # single build, rather than stopping when the first one fails.
       fail-fast: false


### PR DESCRIPTION
So we start to test PHP/8.5 (in development) and the last nginx/1.28.0.

It's working OK with the nightly PHP and last nginx.
https://github.com/rryqszq4/ngx-php/actions/runs/15343140400/job/43173496190#step:10:15

![image](https://github.com/user-attachments/assets/481565ea-1a17-40d8-a63e-19d81f235fbe)


Fixed dependencies.

Commented the tests for Ubuntu/20.04 as end of life is 31 May 2025 (tomorrow). And we have faster tests.

PD: the only fail is for the socket returning a 502 Bad Gateway, that sometimes happen when the other server is saturated.

![image](https://github.com/user-attachments/assets/0de7ce26-a5e3-42a6-a28b-6b8526afe82c)
