### PR TITLE
Nighly build running each month using the dev branch

### DIFF
--- a/.github/workflows/build_development.yml
+++ b/.github/workflows/build_development.yml
@@ -35,8 +35,8 @@ jobs:
 
     strategy:
       matrix:
-        php_version: ["8.4"]
-        nginx_version: ["1.26.0"] 
+        php_version: ["8.5"]
+        nginx_version: ["1.28.0"] 
         # Disable fail-fast to allow all failing versions to fail in a
         # single build, rather than stopping when the first one fails.
       fail-fast: false
@@ -45,6 +45,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with: { ref: development }
+        # with to use development branch
       - name: Install dependencies
         run: sudo apt-get install -yqq cpanminus libxml2-dev systemtap-sdt-dev zlib1g-dev libpcre3-dev libargon2-dev libsodium-dev libkrb5-dev redis-server redis-tools memcached
 


### PR DESCRIPTION
As the scheduled only run in the master branch, we update the master nightly run and using the development branch.

We also need to remove the Ubuntu 20.04 (EOL May 31, 2025), as we have done in the dev branch.

> The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
> 
> March 4 14:00 UTC – 22:00 UTC
> March 11 13:00 UTC – 21:00 UTC
> March 18 13:00 UTC – 21:00 UTC
> March 25 13:00 UTC – 21:00 UTC
> What you need to do
> 
> Jobs using the ubuntu-20.04 YAML workflow label should be updated to ubuntu-22.04, ubuntu-24.04 or ubuntu-latest. You can always get up-to-date information on our tools by reading about the software in the [runner images repository](https://app.github.media/e/er?s=88570519&lid=3455&elqTrackId=1befe7689f3c4a1a9cba67758d7c6fa0&elq=6cdd8e353e5b4a4bbeccb49edc5c1e54&elqaid=4309&elqat=1&elqak=8AF512931A9D3060F4A93E1FC36635281ABFACBE0B96446A3C6AB5FDC4B254BF6889). Please contact GitHub [Support](https://app.github.media/e/er?s=88570519&lid=3338&elqTrackId=51ced43500f64a46924167a4a536829b&elq=6cdd8e353e5b4a4bbeccb49edc5c1e54&elqaid=4309&elqat=1&elqak=8AF5D818E42E3357A6143F29D23F7AD3B3C1ACBE0B96446A3C6AB5FDC4B254BF6889) if you run into any problems or need help.

https://github.com/actions/runner-images

<img width="877" height="706" alt="image" src="https://github.com/user-attachments/assets/b9564622-0958-403b-9263-a912fdcc03f5" />
